### PR TITLE
Add css support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 0.5.3 (2018-11-14)
 
-### Features
+### Maintenace
 
-* added css support in qext-scripts
+* removed unused variable
 
 # 0.5.2 (2018-07-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.3 (2018-11-14)
+
+### Features
+
+* added css support in qext-scripts
+
 # 0.5.2 (2018-07-05)
 
 ### Bug Fixes

--- a/extension-template/extension-template.js
+++ b/extension-template/extension-template.js
@@ -1,10 +1,10 @@
-import initialProperties from './initial-properties.js';
-import template from './template.html';
-import definition from './definition.js';
-import controller from './controller.js';
-import paint from './paint.js';
-import resize from './resize.js';
-import localCSS from './style.scss';
+import initialProperties from "./initial-properties.js";
+import template from "./template.html";
+import definition from "./definition.js";
+import controller from "./controller.js";
+import paint from "./paint.js";
+import resize from "./resize.js";
+import "./style.scss";
 
 export default window.define([], function() {
   return {
@@ -14,5 +14,5 @@ export default window.define([], function() {
     controller: controller,
     paint: paint,
     resize: resize
-  }
-})
+  };
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qext",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "README",
   "main": "index.js",
   "scripts": {

--- a/packages/qext-scripts/CHANGELOG.md
+++ b/packages/qext-scripts/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.6.0 (2018-11-14)
+
+### Features
+* added css support
+
 # 0.5.0 (2018-04-30)
 
 ### Bug Fixes

--- a/packages/qext-scripts/package-lock.json
+++ b/packages/qext-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qext-scripts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/qext-scripts/package.json
+++ b/packages/qext-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qext-scripts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/packages/qext-scripts/scripts/define-webpack.js
+++ b/packages/qext-scripts/scripts/define-webpack.js
@@ -1,5 +1,5 @@
-var Rx = require('rxjs');
-var webpack = require('webpack');
+var Rx = require("rxjs");
+var webpack = require("webpack");
 
 module.exports = function(extensionName) {
   return Rx.Observable.create(observer => {
@@ -14,27 +14,31 @@ module.exports = function(extensionName) {
           {
             test: /\.js$/,
             exclude: /node_modules/,
-            loader: 'babel-loader'
+            loader: "babel-loader"
           },
           {
             test: /\.html$/,
-            loader: 'html-loader'
+            loader: "html-loader"
           },
           {
             test: /\.scss$/,
             use: [
-              { loader: 'style-loader' },
-              { loader: 'css-loader' },
-              { loader: 'sass-loader' }
+              { loader: "style-loader" },
+              { loader: "css-loader" },
+              { loader: "sass-loader" }
             ]
+          },
+          {
+            test: /\.css$/,
+            use: [{ loader: "style-loader" }, { loader: "css-loader" }]
           },
           {
             test: /\.(png|svg|jpg|gif)$/,
             use: [
               {
-                loader: 'file-loader',
+                loader: "file-loader",
                 options: {
-                  name: '[name].[ext]',
+                  name: "[name].[ext]",
                   publicPath: `/extensions/${extensionName}/`
                 }
               }
@@ -44,7 +48,7 @@ module.exports = function(extensionName) {
       }
     });
 
-    observer.next({ extensionName: extensionName, compiler: compiler })
+    observer.next({ extensionName: extensionName, compiler: compiler });
     observer.complete();
-  })
-}
+  });
+};


### PR DESCRIPTION
Added css support in qext-scripts so that users can import css files just like scss files.

Cleaned up an unused variable in qExt template.

Bumped version numbers for both packages