### PR TITLE
Support win-auth not being standard auth

### DIFF
--- a/packages/qext-scripts/src/authenticate/authenticate.js
+++ b/packages/qext-scripts/src/authenticate/authenticate.js
@@ -18,7 +18,7 @@ export default config => {
 			exec(
 				`curl -s -L --ntlm -u ${user}:${password} --insecure -c - ${serverDeploy.isSecure ? "https" : "http"}://${
 					serverDeploy.host
-				}/qrs/about?xrfkey=0123456789abcdef --header "x-qlik-xrfkey: 0123456789abcdef" --header "User-Agent: Windows"`,
+				}${serverDeploy.prefix ? "/" : ""}${serverDeploy.prefix}/qrs/about?xrfkey=0123456789abcdef --header "x-qlik-xrfkey: 0123456789abcdef" --header "User-Agent: Windows"`,
 				/** Callback */
 				(error, stdout, stderr) => {
 					/** Error */


### PR DESCRIPTION
Attempt to fix edge case of win-auth not being the standard authentication. 
Currently you can add prefix to host and authenticate, but cant deploy extensions.
Alternatively you can add prefix to prefix variable and not be able to authenticate. (but would probably be able to deploy)

This change allows prefix to work for win-auth authentication if needed.